### PR TITLE
Support for 1.21.11-fabric

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,11 +13,12 @@ plugins {
     id("dev.deftu.gradle.tools.publishing.maven")
 }
 
-apply(rootProject.file("secrets.gradle.kts"))
+//apply(rootProject.file("secrets.gradle.kts"))
 
 toolkitMultiversion.moveBuildsToRootProject.set(true)
 toolkitLoomHelper.useMixinRefMap(modData.id)
 repositories.maven("https://maven.teamresourceful.com/repository/maven-public/")
+repositories.mavenLocal() // TODO: remove once knit-1.21.11-fabric is published to remote maven
 
 dependencies {
     implementation(kotlin("stdlib-jdk8"))
@@ -35,6 +36,7 @@ dependencies {
     }
 
     when (mcData.version) {
+        MinecraftVersions.VERSION_1_21_11 -> include(modApi("earth.terrarium.olympus:olympus-fabric-1.21.11:1.7.2")!!)
         MinecraftVersions.VERSION_1_21_10 -> include(modApi("earth.terrarium.olympus:olympus-fabric-1.21.9:1.6.2")!!)
         MinecraftVersions.VERSION_1_21_8 -> include(modApi("earth.terrarium.olympus:olympus-fabric-1.21.7:1.5.2")!!)
         MinecraftVersions.VERSION_1_21_5 -> include(modApi("earth.terrarium.olympus:olympus-fabric-1.21.5:1.3.6")!!)

--- a/root.gradle.kts
+++ b/root.gradle.kts
@@ -3,9 +3,11 @@ plugins {
 }
 
 preprocess {
-    "1.21.10-fabric"(1_21_10, "yarn") {
-        "1.21.8-fabric"(1_21_08, "yarn") {
-            "1.21.5-fabric"(1_21_05, "yarn")
+    "1.21.11-fabric"(1_21_11, "yarn") {
+        "1.21.10-fabric"(1_21_10, "yarn") {
+            "1.21.8-fabric"(1_21_08, "yarn") {
+                "1.21.5-fabric"(1_21_05, "yarn")
+            }
         }
     }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ pluginManagement {
 
     plugins {
         kotlin("jvm") version("2.0.0")
-        id("dev.deftu.gradle.multiversion-root") version("2.59.0")
+        id("dev.deftu.gradle.multiversion-root") version("2.73.0")
     }
 }
 
@@ -30,7 +30,8 @@ rootProject.buildFileName = "root.gradle.kts"
 listOf(
     "1.21.5-fabric",
     "1.21.8-fabric",
-    "1.21.10-fabric"
+    "1.21.10-fabric",
+    "1.21.11-fabric"
 ).forEach { version ->
     include(":$version")
     project(":$version").apply {

--- a/versions/1.21.11-fabric/gradle.properties
+++ b/versions/1.21.11-fabric/gradle.properties
@@ -1,0 +1,1 @@
+essential.loom.disableUnpick=true


### PR DESCRIPTION
- Add 1.21.11-fabric to version list and preprocess chain                                                                                                                                         - Add olympus-fabric-1.21.11:1.7.2 dependency
- Bump gradle toolkit from 2.59.0 to 2.73.0 for VERSION_1_21_11 support                                                                                                                           
- Add mavenLocal() temporarily until knit-1.21.11-fabric is published [A link for that pr is here](https://github.com/StellariumMC/Knit/pull/1)